### PR TITLE
E_DEPRECATED

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -561,7 +561,7 @@ class Api
      */
     public function getLabels(array $packages, $decomposition = LabelDecomposition::QUARTER)
     {
-        user_error("getLabels is deprecated, use Label::generateLabels instead.", E_DEPRECATED);
+        user_error("getLabels is deprecated, use Label::generateLabels instead.", E_USER_DEPRECATED);
         return Label::generateLabels($packages, $decomposition);
     }
 }


### PR DESCRIPTION
E_DEPRECATED can only be triggered by PHP itself. For frameworks  shoud by used E_USER_DEPRECATED.