### PR TITLE
getPackages - non existing values

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -256,7 +256,14 @@ class Api
             ]
         ]);
 
-        return $result->GetPackagesResult->ResultData->MyApiPackageOut;
+        if (property_exists($result->GetPackagesResult->ResultData,"MyApiPackageOut"))
+        {
+          return $result->GetPackagesResult->ResultData->MyApiPackageOut;
+        }
+        else
+        {
+          return false;
+        }    
     }
 
     /**


### PR DESCRIPTION
Error occurs when trying to search non existing package. (~ MyApiPackageOut not set)